### PR TITLE
Integrate GlobalExceptionHandler into RouterRestTest

### DIFF
--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/Handler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/Handler.java
@@ -2,7 +2,6 @@ package co.com.pragma.api;
 
 import co.com.pragma.api.dto.UserRequestDTO;
 import co.com.pragma.api.mapper.UserMapper;
-import co.com.pragma.model.logs.gateways.LoggerPort;
 import co.com.pragma.usecase.user.UserUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,7 +15,6 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class Handler {
     private final UserUseCase userUseCase;
-    private final LoggerPort logger;
     private final UserMapper userMapper;
 
     public Mono<ServerResponse> listenPOSTSaveUserUseCase(ServerRequest serverRequest) {

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/RouterRestTest.java
@@ -5,6 +5,7 @@ import co.com.pragma.api.dto.ErrorDTO;
 import co.com.pragma.api.dto.RoleDTO;
 import co.com.pragma.api.dto.UserRequestDTO;
 import co.com.pragma.api.dto.UserResponseDTO;
+import co.com.pragma.api.exception.handler.GlobalExceptionHandler;
 import co.com.pragma.api.mapper.UserMapper;
 import co.com.pragma.model.constants.DefaultValues;
 import co.com.pragma.model.constants.ErrorMessage;
@@ -31,7 +32,7 @@ import java.math.BigDecimal;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@ContextConfiguration(classes = {RouterRest.class, Handler.class})
+@ContextConfiguration(classes = {RouterRest.class, Handler.class, GlobalExceptionHandler.class})
 @WebFluxTest
 class RouterRestTest {
 


### PR DESCRIPTION
This pull request makes minor updates to the reactive web entry point and its test configuration. The most notable changes are the removal of the `LoggerPort` dependency from the `Handler` class and the addition of the `GlobalExceptionHandler` to the test context configuration.

Dependency cleanup:

* Removed the `LoggerPort` dependency from the `Handler` class, simplifying its constructor and reducing unnecessary dependencies. [[1]](diffhunk://#diff-30a1c71b2c4e945bb0fc4ff31717f20a1a254d569f9af70d81da6de8c223c3feL5) [[2]](diffhunk://#diff-30a1c71b2c4e945bb0fc4ff31717f20a1a254d569f9af70d81da6de8c223c3feL19)

Test configuration improvements:

* Added `GlobalExceptionHandler` to the `@ContextConfiguration` in `RouterRestTest` to ensure exception handling is properly tested. [[1]](diffhunk://#diff-16960fde2f46b0ad4d65f5d4ed0b6f2fdb770c9186a0c43d07fa0f563234e6e4R8) [[2]](diffhunk://#diff-16960fde2f46b0ad4d65f5d4ed0b6f2fdb770c9186a0c43d07fa0f563234e6e4L34-R35)