### PR TITLE
Add ID number validation and exception handling

### DIFF
--- a/domain/model/src/main/java/co/com/pragma/model/constants/DefaultValues.java
+++ b/domain/model/src/main/java/co/com/pragma/model/constants/DefaultValues.java
@@ -5,6 +5,8 @@ import java.math.BigDecimal;
 public class DefaultValues {
     private DefaultValues(){}
 
+    public static final boolean ID_NUMBER_UNIQUE = true;
+
     public static final String DEFAULT_ROLE_NAME = "CLIENTE";
     public static final int DEFAULT_ROLE_ID = 3;
     public static final String DEFAULT_ROLE_DESCRIPTION = "Cliente Solicitante";

--- a/domain/model/src/main/java/co/com/pragma/model/constants/ErrorMessage.java
+++ b/domain/model/src/main/java/co/com/pragma/model/constants/ErrorMessage.java
@@ -19,16 +19,19 @@ public final class ErrorMessage {
     public static final String EMAIL_TAKEN_CODE = "U005";
     public static final String EMAIL_TAKEN = "Email is already taken.";
 
-    public static final String SIZE_OUT_OF_BOUNDS_CODE = "U006";
+    public static final String ID_NUMBER_TAKEN_CODE = "U006";
+    public static final String ID_NUMBER_TAKEN = "Id number is already taken.";
+
+    public static final String SIZE_OUT_OF_BOUNDS_CODE = "U007";
     public static final String SIZE_OUT_OF_BOUNDS = "Size out of bounds.";
 
-    public static final String USER_NULL_CODE = "U007";
+    public static final String USER_NULL_CODE = "U008";
     public static final String USER_NULL = "User is null.";
 
-    public static final String ERROR_SAVING_USER_CODE = "U008";
+    public static final String ERROR_SAVING_USER_CODE = "U009";
     public static final String ERROR_SAVING_USER = "Error saving user.";
 
-    public static final String USER_FIELD_ERROR_CODE = "U009";
+    public static final String USER_FIELD_ERROR_CODE = "U010";
     public static final String USER_FIELD_ERROR = "Error in user field.";
 
     public static final String ROL_NOT_FOUND_CODE = "R001";

--- a/domain/model/src/main/java/co/com/pragma/model/exceptions/IdNumberTakenException.java
+++ b/domain/model/src/main/java/co/com/pragma/model/exceptions/IdNumberTakenException.java
@@ -1,0 +1,11 @@
+package co.com.pragma.model.exceptions;
+
+import co.com.pragma.model.constants.ErrorMessage;
+
+import static java.net.HttpURLConnection.HTTP_CONFLICT;
+
+public class IdNumberTakenException extends CustomException {
+    public IdNumberTakenException() {
+        super(ErrorMessage.ID_NUMBER_TAKEN, ErrorMessage.ID_NUMBER_TAKEN_CODE, HTTP_CONFLICT);
+    }
+}

--- a/domain/usecase/src/main/java/co/com/pragma/usecase/user/UserUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/usecase/user/UserUseCase.java
@@ -1,10 +1,13 @@
 package co.com.pragma.usecase.user;
 
+import co.com.pragma.model.constants.DefaultValues;
 import co.com.pragma.model.constants.ErrorMessage;
 import co.com.pragma.model.constants.LogMessages;
-import co.com.pragma.model.exceptions.*;
+import co.com.pragma.model.exceptions.EmailTakenException;
+import co.com.pragma.model.exceptions.IdNumberTakenException;
+import co.com.pragma.model.exceptions.RoleNotFoundException;
+import co.com.pragma.model.exceptions.UserNullException;
 import co.com.pragma.model.logs.gateways.LoggerPort;
-import co.com.pragma.model.role.Role;
 import co.com.pragma.model.role.gateways.RoleRepository;
 import co.com.pragma.model.transaction.gateways.TransactionalPort;
 import co.com.pragma.model.user.User;
@@ -25,24 +28,6 @@ public class UserUseCase {
     private final LoggerPort logger;
     private final TransactionalPort transactionalPort;
 
-    /**
-     * Saves a new user in the system after performing business validations.
-     * <p>
-     * This method orchestrates the entire user creation process. It first validates the input,
-     * assigns a default role if none is provided, and then executes the database operations
-     * within a single transaction to ensure data integrity.
-     *
-     * @param user The {@link User} object to be saved. It must not be null.
-     * @return A {@link Mono} that emits the saved {@link User} with its new ID upon success.
-     *         If any validation or persistence error occurs, the Mono will emit an error.
-     * @throws UserNullException if the provided user object is null.
-     * @throws FieldBlankException if a required field (like name, lastName, email, or baseSalary) is null or blank.
-     * @throws FieldSizeOutOfBoundsException if a field's length exceeds its defined maximum.
-     * @throws SalaryUnboundException if the baseSalary is outside the allowed range.
-     * @throws EmailFormatException if the email does not match the required format.
-     * @throws RoleNotFoundException if the specified role does not exist in the system.
-     * @throws EmailTakenException if the provided email is already in use by another user.
-     */
     public Mono<User> saveUser(User user) {
         return Mono.justOrEmpty(user)
                 .switchIfEmpty(Mono.defer(() -> Mono.error(new UserNullException())))
@@ -58,45 +43,39 @@ public class UserUseCase {
 
     // START Private methods ***********************************************************
 
-    /**
-     * Orchestrates the sequence of database operations that must be transactional.
-     * This includes finding the role, checking for email existence, and saving the user.
-     *
-     * @param user The user to be processed.
-     * @return A {@link Mono} that emits the saved user if all operations succeed.
-     */
     private Mono<User> saveUserTransaction(User user) {
         return findAndValidateRole(user)
-                .flatMap(role -> checkEmail(user, role))
+                .flatMap(userWithRole ->
+                        Mono.when(
+                                    checkEmail(userWithRole),
+                                    checkIdNumber(userWithRole)
+                                )
+                                .thenReturn(userWithRole)
+                )
                 .flatMap(userRepository::save);
     }
 
-    /**
-     * Finds the user's role in the repository.
-     * If the role is not found, it emits a {@link RoleNotFoundException}.
-     *
-     * @param user The user whose role is to be found.
-     * @return A {@link Mono} that emits the found {@link Role}.
-     */
-    private Mono<Role> findAndValidateRole(User user) {
+    private Mono<User> findAndValidateRole(User user) {
         return roleRepository.findOne(user.getRole())
-                .switchIfEmpty(Mono.defer(() -> Mono.error(new RoleNotFoundException())));
+                .switchIfEmpty(Mono.defer(() -> Mono.error(new RoleNotFoundException())))
+                .map(role -> user.toBuilder().role(role).build());
     }
 
-    /**
-     * Checks if the user's email already exists.
-     * If it exists, it emits an {@link EmailTakenException}.
-     * If it does not exist, it prepares the user object with the validated role for saving.
-     *
-     * @param user The user object being processed.
-     * @param role The validated role to be associated with the user.
-     * @return A {@link Mono} containing the user ready to be saved.
-     */
-    private Mono<User> checkEmail(User user, Role role) {
+    private Mono<Void> checkEmail(User user) {
         return userRepository.exists(User.builder().email(user.getEmail()).build())
                 .filter(exists -> !exists)
                 .switchIfEmpty(Mono.defer(() -> Mono.error(new EmailTakenException())))
-                .flatMap(exists -> Mono.just(user.toBuilder().role(role).build()));
+                .then();
+    }
+
+    private Mono<Void> checkIdNumber(User user) {
+        if (!DefaultValues.ID_NUMBER_UNIQUE) {
+            return Mono.empty();
+        }
+        return userRepository.exists(User.builder().idNumber(user.getIdNumber()).build())
+                .filter(exists -> !exists)
+                .switchIfEmpty(Mono.defer(() -> Mono.error(new IdNumberTakenException())))
+                .then();
     }
 
     // END Private methods ***********************************************************

--- a/domain/usecase/src/main/java/co/com/pragma/usecase/user/utils/UserUtils.java
+++ b/domain/usecase/src/main/java/co/com/pragma/usecase/user/utils/UserUtils.java
@@ -56,6 +56,7 @@ public class UserUtils {
         return ValidationUtils.validateCondition(user.getName() != null && !user.getName().isBlank(), () -> new FieldBlankException(DefaultValues.NAME_FIELD))
                 .then(ValidationUtils.validateCondition(user.getLastName() != null && !user.getLastName().isBlank(), () -> new FieldBlankException(DefaultValues.LAST_NAME_FIELD)))
                 .then(ValidationUtils.validateCondition(user.getEmail() != null && !user.getEmail().isBlank(), () -> new FieldBlankException(DefaultValues.EMAIL_FIELD)))
+                .then(ValidationUtils.validateCondition(user.getIdNumber() != null && !user.getIdNumber().isBlank(), () -> new FieldBlankException(DefaultValues.ID_NUMBER_FIELD)))
                 .then(ValidationUtils.validateCondition(user.getBaseSalary() != null, () -> new FieldBlankException(DefaultValues.SALARY_FIELD)));
     }
 
@@ -69,7 +70,7 @@ public class UserUtils {
         return ValidationUtils.validateCondition(user.getName().length() <= DefaultValues.MAX_LENGTH_NAME, () -> new FieldSizeOutOfBoundsException(DefaultValues.NAME_FIELD))
                 .then(ValidationUtils.validateCondition(user.getLastName().length() <= DefaultValues.MAX_LENGTH_LAST_NAME, () -> new FieldSizeOutOfBoundsException(DefaultValues.LAST_NAME_FIELD)))
                 .then(ValidationUtils.validateCondition(user.getEmail().length() <= DefaultValues.MAX_LENGTH_EMAIL, () -> new FieldSizeOutOfBoundsException(DefaultValues.EMAIL_FIELD)))
-                .then(ValidationUtils.validateCondition(user.getIdNumber() == null || user.getIdNumber().length() <= DefaultValues.MAX_LENGTH_ID_NUMBER, () -> new FieldSizeOutOfBoundsException(DefaultValues.ID_NUMBER_FIELD)))
+                .then(ValidationUtils.validateCondition(user.getIdNumber().length() <= DefaultValues.MAX_LENGTH_ID_NUMBER, () -> new FieldSizeOutOfBoundsException(DefaultValues.ID_NUMBER_FIELD)))
                 .then(ValidationUtils.validateCondition(user.getPhone() == null || user.getPhone().length() <= DefaultValues.MAX_LENGTH_PHONE, () -> new FieldSizeOutOfBoundsException(DefaultValues.PHONE_FIELD)))
                 .then(ValidationUtils.validateCondition(user.getAddress() == null || user.getAddress().length() <= DefaultValues.MAX_LENGTH_ADDRESS, () -> new FieldSizeOutOfBoundsException(DefaultValues.ADDRESS_FIELD)))
                 .then(ValidationUtils.validateCondition(user.getBaseSalary().compareTo(DefaultValues.MIN_SALARY) >= 0, SalaryUnboundException::new))

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/resources/db/migration/V1__create_user_and_role_tables.sql
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/resources/db/migration/V1__create_user_and_role_tables.sql
@@ -12,7 +12,7 @@ CREATE TABLE Usuario (
   nombre VARCHAR(50) NOT NULL,
   apellido VARCHAR(50) NOT NULL,
   email VARCHAR(100) NOT NULL UNIQUE,
-  documento_identidad VARCHAR(50) NULL,
+  documento_identidad VARCHAR(50) NOT NULL,
   id_rol INT NOT NULL,
   salario_base DECIMAL(10, 2) NOT NULL,
   telefono VARCHAR(20) NULL,

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -86,6 +86,7 @@ public class ApiConstants {
         public static final String LAST_NAME_NOT_BLANK = "Last name can't be empty";
         public static final String LAST_NAME_SIZE = "Last name must have less than 50 characters";
         public static final String EMAIL_NOT_BLANK = "Email can't be empty";
+        public static final String ID_NUMBER_NOT_BLANK = "Id number can't be empty";
         public static final String EMAIL_VALID = "Email should be valid";
         public static final String EMAIL_SIZE = "Email must have less than 100 characters";
         public static final String ID_NUMBER_SIZE = "Id Number must have less than 50 characters";

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/UserRequestDTO.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/UserRequestDTO.java
@@ -40,6 +40,7 @@ public class UserRequestDTO {
     @Schema(description = ApiConstants.User.DESCRIPTION_EMAIL, example = ApiConstants.User.EXAMPLE_EMAIL)
     private String email;
 
+    @NotBlank(message = ApiConstants.ValidationMessages.ID_NUMBER_NOT_BLANK)
     @Size(max = 50, message = ApiConstants.ValidationMessages.ID_NUMBER_SIZE)
     @Schema(description = ApiConstants.User.DESCRIPTION_ID_NUMBER, example = ApiConstants.User.EXAMPLE_ID_NUMBER)
     private String idNumber;


### PR DESCRIPTION
This pull request introduces validation and uniqueness enforcement for the user's ID number throughout the domain and API layers. The changes ensure that the `idNumber` field is required, must not be blank, must adhere to length constraints, and is unique across users. The codebase and tests are updated to reflect these new requirements.

**ID Number Validation and Uniqueness Enforcement**

* Added `ID_NUMBER_UNIQUE` constant to `DefaultValues` and enforced uniqueness for `idNumber` in the user creation logic, including a new `IdNumberTakenException` for handling conflicts. (`domain/model/src/main/java/co/com/pragma/model/constants/DefaultValues.java` [[1]](diffhunk://#diff-1878cfbb493d0e90171d57de3fb4b021ce82598c1fc88e98c426ff45f38be49bR8-R9) `domain/model/src/main/java/co/com/pragma/model/exceptions/IdNumberTakenException.java` [[2]](diffhunk://#diff-4387869415bc831e96ceee2c1be15a4e8aabae803b5966727df4dbce2f2800baR1-R11) `domain/usecase/src/main/java/co/com/pragma/usecase/user/UserUseCase.java` [[3]](diffhunk://#diff-052b6162ee8b2d634ccec291ef565ec5edfb4fd7fddfef46526d26de1f63ccc2L61-R78)
* Updated error codes and messages to include `ID_NUMBER_TAKEN` and shifted other codes accordingly in `ErrorMessage`. (`domain/model/src/main/java/co/com/pragma/model/constants/ErrorMessage.java` [domain/model/src/main/java/co/com/pragma/model/constants/ErrorMessage.javaL22-R34](diffhunk://#diff-4ae430955bda29f4a6d7277270c7ec12e88de0e2f9406cf827ac0f25ca22a9e0L22-R34))
* Modified the user validation utilities to require `idNumber` to be non-blank and within length bounds. (`domain/usecase/src/main/java/co/com/pragma/usecase/user/utils/UserUtils.java` [[1]](diffhunk://#diff-bb8a0dc4ce10e47a2383ff5b0d6aed275be81e88fa77777a26268cd665a088ffR59) [[2]](diffhunk://#diff-bb8a0dc4ce10e47a2383ff5b0d6aed275be81e88fa77777a26268cd665a088ffL72-R73)
* Database schema updated to make `documento_identidad` (ID number) non-nullable, enforcing the requirement at the persistence level. (`infrastructure/driven-adapters/r2dbc-mysql/src/main/resources/db/migration/V1__create_user_and_role_tables.sql` [infrastructure/driven-adapters/r2dbc-mysql/src/main/resources/db/migration/V1__create_user_and_role_tables.sqlL15-R15](diffhunk://#diff-0b33c935e531cfc1347511d700f13cf127c39ce0f81f1e886066a36c3545fe10L15-R15))

**API and DTO Layer Updates**

* Added validation annotations to `idNumber` in `UserRequestDTO`, requiring it to be non-blank and within 50 characters, with corresponding validation messages. (`infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/dto/UserRequestDTO.java` [[1]](diffhunk://#diff-130ec2831d6922190a81023776a9ca15ff12ca0f16916d7eb7cb33b93f93bc1eR43) `infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java` [[2]](diffhunk://#diff-7a98c042e382b1d0209a9b4303b5196a188eaf9c235c3ed02ce2c4ac1f18fee8R89)

**Test Enhancements**

* Updated and expanded unit tests to cover scenarios for blank, invalid, duplicate, and valid `idNumber` values, ensuring correct exception handling and repository interactions. (`domain/usecase/src/test/java/co/com/pragma/usecase/user/UserUseCaseTest.java` [[1]](diffhunk://#diff-8ced740d6b56c8fdd74b2624f23664c836d8901804298bc3ad7cc4519ba58afbL71-R85) [[2]](diffhunk://#diff-8ced740d6b56c8fdd74b2624f23664c836d8901804298bc3ad7cc4519ba58afbR94-R104) [[3]](diffhunk://#diff-8ced740d6b56c8fdd74b2624f23664c836d8901804298bc3ad7cc4519ba58afbR113-R124) [[4]](diffhunk://#diff-8ced740d6b56c8fdd74b2624f23664c836d8901804298bc3ad7cc4519ba58afbR179-R188) [[5]](diffhunk://#diff-8ced740d6b56c8fdd74b2624f23664c836d8901804298bc3ad7cc4519ba58afbL259-R284) [[6]](diffhunk://#diff-8ced740d6b56c8fdd74b2624f23664c836d8901804298bc3ad7cc4519ba58afbR294-R330)

These changes collectively ensure that the user's ID number is always present, validated, and unique, improving data integrity and error handling across the system.