### PR TITLE
Hu/07 loan autovalidation

### DIFF
--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -5,6 +5,7 @@ import co.com.pragma.api.constants.ApiConstants.ApiPathMatchers;
 import co.com.pragma.api.exception.handler.CustomAccessDeniedHandler;
 import co.com.pragma.model.jwt.JwtData;
 import co.com.pragma.model.jwt.gateways.JwtProviderPort;
+import co.com.pragma.model.logs.gateways.LoggerPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +31,7 @@ public class WebSecurityConfig {
 
     private final JwtProviderPort jwtProvider;
     private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final LoggerPort logger;
 
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
@@ -46,6 +48,11 @@ public class WebSecurityConfig {
                                 ApiPathMatchers.SWAGGER_UI_MATCHER,
                                 ApiConstants.ApiPaths.SWAGGER_PATH
                         ).permitAll()
+                        .pathMatchers(
+                                ApiPathMatchers.USER_BY_EMAIL_MATCHER
+                        ).hasAnyAuthority(
+                                ApiConstants.Role.CLIENT_ROLE_NAME
+                        )
                         .pathMatchers(
                                 ApiPathMatchers.SEARCHES_MATCHER
                         ).hasAnyAuthority(
@@ -81,6 +88,7 @@ public class WebSecurityConfig {
                     String email = jwtData.subject();
                     List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(jwtData.role()));
                     Authentication auth = new UsernamePasswordAuthenticationToken(email, authToken, authorities);
+                    logger.info("User {} logged in, with role {}", email, jwtData.role());
                     return Mono.just(new SecurityContextImpl(auth));
                 } catch (Exception e) {
                     return Mono.empty();

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -40,6 +40,8 @@ public class ApiConstants {
         public static final String USER_MATCHER = ApiPaths.USERS_PATH + "/**";
         //ASESOR
         public static final String SEARCHES_MATCHER = ApiPaths.SEARCHES_PATH + "/**";
+        //CLIENTE
+        public static final String USER_BY_EMAIL_MATCHER = ApiPaths.SEARCHES_PATH + "/email/**";
         //TEST ENDPOINT
         public static final String TEST_MATCHER = "/test-endpoint";
         public static final String DUMMY_USER_DOC_ROUTE = "/dummy-user-doc-route";

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/api/RouterRestTest.java
@@ -301,7 +301,7 @@ class RouterRestTest {
     }
 
     @Test
-    @WithMockUser(authorities = "ASESOR")
+    @WithMockUser(authorities = "CLIENTE")
     void findUserByEmail_shouldReturnOk_whenUserIsFound() {
         String email = "john.doe@example.com";
         when(userUseCase.findByEmail(email)).thenReturn(Mono.just(User.builder().email(email).build()));


### PR DESCRIPTION
This pull request updates the security configuration to introduce a new endpoint matcher for user lookup by email, restricts its access to users with the CLIENT role, and adds improved logging for authentication events. It also updates related constants and adjusts a test to align with the new role-based access control.

**Security configuration updates:**

* Added a new path matcher `USER_BY_EMAIL_MATCHER` for endpoints matching `/searches/email/**`, and restricted access to users with the CLIENT role in `WebSecurityConfig`. [[1]](diffhunk://#diff-212223003c0b8b49cd05b516c0774d044949dbc747bd182d586d832d3feddb32R51-R55) [[2]](diffhunk://#diff-7a98c042e382b1d0209a9b4303b5196a188eaf9c235c3ed02ce2c4ac1f18fee8R43-R44)
* Injected the `LoggerPort` dependency into `WebSecurityConfig` for improved logging. [[1]](diffhunk://#diff-212223003c0b8b49cd05b516c0774d044949dbc747bd182d586d832d3feddb32R8) [[2]](diffhunk://#diff-212223003c0b8b49cd05b516c0774d044949dbc747bd182d586d832d3feddb32R34)
* Added logging of user email and role upon successful authentication in the security context loader.

**Testing adjustments:**

* Updated the `findUserByEmail_shouldReturnOk_whenUserIsFound` test to use the CLIENT role instead of ASESOR, reflecting the new access restriction.