### PR TITLE
Rename `MainApplication` to `AuthServiceApplication` for clarity and …

### DIFF
--- a/applications/app-service/src/main/java/co/com/pragma/AuthServiceApplication.java
+++ b/applications/app-service/src/main/java/co/com/pragma/AuthServiceApplication.java
@@ -9,8 +9,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableConfigurationProperties(AdminUserProperties.class)
-public class MainApplication {
+public class AuthServiceApplication {
     public static void main(String[] args) {
-        SpringApplication.run(MainApplication.class, args);
+        SpringApplication.run(AuthServiceApplication.class, args);
     }
 }


### PR DESCRIPTION
This pull request makes a small but important change by renaming the main application class to better reflect its purpose.

- Renamed the main application class from `MainApplication` to `AuthServiceApplication` and updated its usage accordingly. (`applications/app-service/src/main/java/co/com/pragma/AuthServiceApplication.java`)…consistency.