### PR TITLE
HU10 update dockerfile

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -4,12 +4,14 @@ WORKDIR /workspace/app
 COPY build.gradle settings.gradle gradlew gradle.properties ./
 COPY gradle ./gradle
 COPY main.gradle .
-RUN ./gradlew dependencies
+RUN sed -i 's/\r$//' ./gradlew && \
+     chmod +x ./gradlew && \
+     ./gradlew dependencies
 COPY applications ./applications
 COPY domain ./domain
 COPY infrastructure ./infrastructure
 
-RUN chmod +x ./gradlew && ./gradlew build -x test
+RUN ./gradlew build -x test
 
 
 # RUNTIME STAGE -----------------------------------


### PR DESCRIPTION
This pull request updates the Docker build process to ensure the `gradlew` script is properly formatted and executable before running dependency installation. This change improves cross-platform compatibility and prevents potential issues with line endings or permissions during the build.

**Build process improvements:**

* Added a `sed` command to remove Windows-style carriage return characters from `gradlew`, and set executable permissions before running `./gradlew dependencies` to prevent execution errors in Unix-based Docker environments.
* Removed redundant `chmod +x ./gradlew` command before the build step, as permissions are now set earlier in the process.