### PR TITLE
dev2main

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -1,0 +1,54 @@
+name: Build and Push Docker Image to ECR
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-push:
+    name: Build and Push to ECR
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./deployment/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -4,12 +4,14 @@ WORKDIR /workspace/app
 COPY build.gradle settings.gradle gradlew gradle.properties ./
 COPY gradle ./gradle
 COPY main.gradle .
-RUN ./gradlew dependencies
+RUN sed -i 's/\r$//' ./gradlew && \
+     chmod +x ./gradlew && \
+     ./gradlew dependencies
 COPY applications ./applications
 COPY domain ./domain
 COPY infrastructure ./infrastructure
 
-RUN chmod +x ./gradlew && ./gradlew build -x test
+RUN ./gradlew build -x test
 
 
 # RUNTIME STAGE -----------------------------------


### PR DESCRIPTION
This pull request updates the Docker build process to improve compatibility and reliability when running Gradle commands. The main change ensures that the `gradlew` script has the correct line endings and execute permissions before it is used.

Build process improvements:

* Added a `sed` command to remove Windows-style carriage return characters from the `gradlew` script and set execute permissions before running `./gradlew dependencies`, which helps prevent execution errors in Unix-based environments.
* Removed a redundant `chmod +x ./gradlew` command in a later build step, as permissions are now set earlier in the process.