### PR TITLE
Hu 10

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -35,8 +35,6 @@ management:
     health:
       probes:
         enabled: true
-  server:
-    port: 9090
 
 cors:
   allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:8081}"


### PR DESCRIPTION
This pull request makes a small configuration update by removing the explicit `server.port` setting from the `application.yaml` file. The application will now use the default server port unless overridden elsewhere.