### PR TITLE
HU 10

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -35,8 +35,6 @@ management:
     health:
       probes:
         enabled: true
-  server:
-    port: 9090
 
 cors:
   allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:4200,http://localhost:8081}"


### PR DESCRIPTION
This pull request makes a minor configuration update by removing the `server.port` setting from the `application.yaml` file. The application will now use the default server port unless specified elsewhere. 

([applications/app-service/src/main/resources/application.yamlL38-L39](diffhunk://#diff-13558ad2b7d64d2abb71070b44165e7110a99238a701565d40192be7ac95c948L38-L39))This enables manual triggering of the deployment workflows. The change provides greater flexibility for running the workflows outside of automatic tag pushes.