### PR TITLE
Update WebSecurityConfig error handling for consistent behavior

### DIFF
--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package co.com.pragma.api.config;
 import co.com.pragma.api.constants.ApiConstants;
 import co.com.pragma.api.constants.ApiConstants.ApiPathMatchers;
 import co.com.pragma.api.exception.handler.CustomAccessDeniedHandler;
+import co.com.pragma.model.exceptions.InvalidCredentialsException;
 import co.com.pragma.model.jwt.JwtData;
 import co.com.pragma.model.jwt.gateways.JwtProviderPort;
 import co.com.pragma.model.logs.gateways.LoggerPort;
@@ -99,7 +100,7 @@ public class WebSecurityConfig {
                     logger.info("User {} logged in, with role {}", email, jwtData.role());
                     return Mono.just(new SecurityContextImpl(auth));
                 } catch (Exception e) {
-                    return Mono.empty();
+                    return Mono.error(new InvalidCredentialsException());
                 }
             }
             return Mono.empty();


### PR DESCRIPTION
This pull request updates the security context loading logic in the `WebSecurityConfig` class to improve error handling when invalid credentials are encountered. Instead of silently failing, the system now throws a specific exception, which can help with debugging and user feedback.

**Authentication error handling:**

* Changed the behavior in the `load(ServerWebExchange exchange)` method to throw an `InvalidCredentialsException` when an authentication error occurs, instead of returning an empty result. This makes authentication failures more explicit and easier to handle.
* Added an import statement for the `InvalidCredentialsException` class to support the new exception handling logic.