### PR TITLE
Develop

### DIFF
--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -3,6 +3,7 @@ package co.com.pragma.api.config;
 import co.com.pragma.api.constants.ApiConstants;
 import co.com.pragma.api.constants.ApiConstants.ApiPathMatchers;
 import co.com.pragma.api.exception.handler.CustomAccessDeniedHandler;
+import co.com.pragma.model.exceptions.InvalidCredentialsException;
 import co.com.pragma.model.jwt.JwtData;
 import co.com.pragma.model.jwt.gateways.JwtProviderPort;
 import co.com.pragma.model.logs.gateways.LoggerPort;
@@ -99,7 +100,7 @@ public class WebSecurityConfig {
                     logger.info("User {} logged in, with role {}", email, jwtData.role());
                     return Mono.just(new SecurityContextImpl(auth));
                 } catch (Exception e) {
-                    return Mono.empty();
+                    return Mono.error(new InvalidCredentialsException());
                 }
             }
             return Mono.empty();


### PR DESCRIPTION
This pull request updates the authentication error handling in the `WebSecurityConfig` class to provide more explicit feedback when invalid credentials are encountered during JWT authentication. Instead of silently failing, the system now throws a specific exception, improving error traceability and security response.

**Authentication error handling:**

* Updated the JWT authentication logic in `WebSecurityConfig.java` to throw an `InvalidCredentialsException` when authentication fails, instead of returning an empty result. This makes authentication errors more explicit and easier to handle downstream.
* Added an import for `InvalidCredentialsException` to support the new error handling behavior.