### PR TITLE
Update API path constants and swagger

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -46,10 +46,11 @@ springdoc:
       title: "Crediya Auth API Microservice"
       version: "1.0.0"
       description: "This is the API for Crediya Auth Microservice"
+    path: /auth/api-docs
   swagger-ui:
     path: /auth/swagger-ui.html
     public-urls:
-      - /api/v1/auth/login
+      - /api/v1/login
   paths-to-exclude:
     - /api/v1/usuarios/{idNumber}
     - /api/v1/busquedas/emails

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -18,7 +18,7 @@ public class ApiConstants {
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class ApiPaths {
-        public static final String SWAGGER_PATH = "/swagger-ui.html";
+        public static final String SWAGGER_PATH = "/auth/swagger-ui.html";
         public static final String BASE_PATH = "/api/v1";
         public static final String USERS_PATH = BASE_PATH + "/usuarios";
         public static final String SEARCHES_PATH = BASE_PATH + "/busquedas";
@@ -34,8 +34,8 @@ public class ApiConstants {
     public static final class ApiPathMatchers {
         //PERMIT ALL
         public static final String LOGIN_MATCHER = ApiPaths.LOGIN_PATH + "/**";
-        public static final String API_DOCS_MATCHER = "/v3/api-docs/**";
-        public static final String SWAGGER_UI_MATCHER = "/swagger-ui/**";
+        public static final String API_DOCS_MATCHER = "/auth/api-docs/**";
+        public static final String SWAGGER_UI_MATCHER = "/auth/swagger-ui/**";
         //ADMIN/ASESOR
         public static final String USER_MATCHER = ApiPaths.USERS_PATH + "/**";
         //ASESOR
@@ -43,8 +43,8 @@ public class ApiConstants {
         //CLIENTE
         public static final String USER_BY_EMAIL_MATCHER = ApiPaths.SEARCHES_PATH + "/email/**";
         //SUPER_USER
-        public static final String ACTUATOR_MATCHER = "/actuator/**";
-        public static final String HEALTH_CHECK_MATCHER = "/actuator/health/**";
+        public static final String ACTUATOR_MATCHER = "/auth/actuator/**";
+        public static final String HEALTH_CHECK_MATCHER = "/auth/actuator/health/**";
         //TEST ENDPOINT
         public static final String TEST_MATCHER = "/test-endpoint";
         public static final String DUMMY_USER_DOC_ROUTE = "/dummy-user-doc-route";


### PR DESCRIPTION
This pull request updates the API documentation and actuator endpoint paths to include an `/auth` prefix, aligning the configuration and Java constants with the new routing scheme. These changes ensure that all relevant endpoints are properly namespaced under `/auth`, improving clarity and consistency across the application.

**API Documentation and Swagger Path Updates:**

* Changed the OpenAPI documentation path to `/auth/api-docs` and the Swagger UI path to `/auth/swagger-ui.html` in `application.yaml`, and updated the public URLs accordingly.
* Updated the `SWAGGER_PATH` constant in `ApiConstants.java` to `/auth/swagger-ui.html` to match the new path.
* Updated the API docs and Swagger UI matchers in `ApiConstants.java` to `/auth/api-docs/**` and `/auth/swagger-ui/**` respectively, ensuring route matching is consistent with the new paths.

**Actuator Endpoints Namespace Update:**

* Updated the actuator and health check matcher constants in `ApiConstants.java` to `/auth/actuator/**` and `/auth/actuator/health/**`, namespacing these endpoints under `/auth`.

**Login Endpoint Public URL Update:**

* Changed the public URL for the login endpoint in `application.yaml` from `/api/v1/auth/login` to `/api/v1/login` to reflect the correct route.