### PR TITLE
Develop

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -46,10 +46,11 @@ springdoc:
       title: "Crediya Auth API Microservice"
       version: "1.0.0"
       description: "This is the API for Crediya Auth Microservice"
+    path: /auth/api-docs
   swagger-ui:
     path: /auth/swagger-ui.html
     public-urls:
-      - /api/v1/auth/login
+      - /api/v1/login
   paths-to-exclude:
     - /api/v1/usuarios/{idNumber}
     - /api/v1/busquedas/emails

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -18,7 +18,7 @@ public class ApiConstants {
 
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static final class ApiPaths {
-        public static final String SWAGGER_PATH = "/swagger-ui.html";
+        public static final String SWAGGER_PATH = "/auth/swagger-ui.html";
         public static final String BASE_PATH = "/api/v1";
         public static final String USERS_PATH = BASE_PATH + "/usuarios";
         public static final String SEARCHES_PATH = BASE_PATH + "/busquedas";
@@ -34,8 +34,8 @@ public class ApiConstants {
     public static final class ApiPathMatchers {
         //PERMIT ALL
         public static final String LOGIN_MATCHER = ApiPaths.LOGIN_PATH + "/**";
-        public static final String API_DOCS_MATCHER = "/v3/api-docs/**";
-        public static final String SWAGGER_UI_MATCHER = "/swagger-ui/**";
+        public static final String API_DOCS_MATCHER = "/auth/api-docs/**";
+        public static final String SWAGGER_UI_MATCHER = "/auth/swagger-ui/**";
         //ADMIN/ASESOR
         public static final String USER_MATCHER = ApiPaths.USERS_PATH + "/**";
         //ASESOR
@@ -43,8 +43,8 @@ public class ApiConstants {
         //CLIENTE
         public static final String USER_BY_EMAIL_MATCHER = ApiPaths.SEARCHES_PATH + "/email/**";
         //SUPER_USER
-        public static final String ACTUATOR_MATCHER = "/actuator/**";
-        public static final String HEALTH_CHECK_MATCHER = "/actuator/health/**";
+        public static final String ACTUATOR_MATCHER = "/auth/actuator/**";
+        public static final String HEALTH_CHECK_MATCHER = "/auth/actuator/health/**";
         //TEST ENDPOINT
         public static final String TEST_MATCHER = "/test-endpoint";
         public static final String DUMMY_USER_DOC_ROUTE = "/dummy-user-doc-route";


### PR DESCRIPTION
This pull request updates the API documentation and actuator endpoint paths to ensure they are properly namespaced under `/auth`, improving clarity and security for the Crediya Auth Microservice. The changes affect both the configuration files and the Java constants used for route matching.

Key changes:

**API documentation and Swagger UI paths:**

* Updated the OpenAPI documentation (`springdoc`) and Swagger UI endpoints to be available under `/auth/api-docs` and `/auth/swagger-ui.html` respectively, instead of the default locations. [[1]](diffhunk://#diff-13558ad2b7d64d2abb71070b44165e7110a99238a701565d40192be7ac95c948R49-R53) [[2]](diffhunk://#diff-7a98c042e382b1d0209a9b4303b5196a188eaf9c235c3ed02ce2c4ac1f18fee8L21-R21) [[3]](diffhunk://#diff-7a98c042e382b1d0209a9b4303b5196a188eaf9c235c3ed02ce2c4ac1f18fee8L37-R47)
* Adjusted the public URLs and matchers for API documentation and Swagger UI in both the YAML configuration and Java constants to reflect the new `/auth` namespace. [[1]](diffhunk://#diff-13558ad2b7d64d2abb71070b44165e7110a99238a701565d40192be7ac95c948R49-R53) [[2]](diffhunk://#diff-7a98c042e382b1d0209a9b4303b5196a188eaf9c235c3ed02ce2c4ac1f18fee8L21-R21) [[3]](diffhunk://#diff-7a98c042e382b1d0209a9b4303b5196a188eaf9c235c3ed02ce2c4ac1f18fee8L37-R47)

**Actuator endpoints:**

* Changed the actuator and health check endpoints to be under `/auth/actuator/**` and `/auth/actuator/health/**` for improved namespacing and potential security benefits.

**Login endpoint update:**

* Modified the public login URL from `/api/v1/auth/login` to `/api/v1/login` in the configuration to align with updated routing.