### PR TITLE
Hu/10 deploy producction

### DIFF
--- a/.github/workflows/deploy-to-ecr.yml
+++ b/.github/workflows/deploy-to-ecr.yml
@@ -3,8 +3,8 @@ name: Build and Push Docker Image to ECR
 on:
   workflow_dispatch:
   push:
-    tags:
-      - 'v*.*.*'
+    branches:
+      - "main"
 
 jobs:
   build-and-push:
@@ -42,8 +42,7 @@ jobs:
         with:
           images: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_PUBLIC_ALIAS }}/${{ secrets.ECR_REPOSITORY }}
           tags: |
-            type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/applications/app-service/src/main/resources/application-local.yaml
+++ b/applications/app-service/src/main/resources/application-local.yaml
@@ -3,6 +3,11 @@ spring:
     url: jdbc:mysql://${SPRING_R2DBC_HOST:localhost}:${SPRING_R2DBC_PORT:3306}/${SPRING_R2DBC_DB:auth_db}
     user: ${SPRING_DB_USERNAME:jpriva}
     password: ${SPRING_DB_PASSWORD:pass12345}
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${SECURITY_PUBLIC_KEY_URI:http://localhost:8081/.well-known/jwks.json}
 
 adapters:
   r2dbc:
@@ -12,9 +17,52 @@ adapters:
     username: ${SPRING_DB_USERNAME:jpriva}
     password: ${SPRING_DB_PASSWORD:pass12345}
 
+logging:
+  level:
+    co.com.pragma.api.exception.handler: DEBUG
+    org.springframework.security.oauth2.jwt: DEBUG
+    org.springframework.security.oauth2.server.resource: DEBUG
+    reactor.netty.http.client: DEBUG
+
 security:
   jwt:
-    secret: ${JWT_SECRET:iBdGbA8Dxowf12Zs7IYH91+KwKOg5yb39RGQv6pOWes=}
+    private-key: "-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDdYk0RoHnJgMqS
+5LUGPDj8wZB8hA9Iwzs1RynJBzvdDjpFoYe4YCKjtoVmJ9dYw4OuHb7UA+7nn+zt
+cEUOrBjTgUDiw6QcFPMxMwdhYd5E0rsuoJn9+8B7PTnhMxcGR3argemOzsELMusG
+iQae1rSLySm9p0RMSjJGC8eRDJHItIdGtxaq2QcyjMNaucia6NvQx5+6vAeOICdm
+VvzxszS5JlLE+jIC78OLw63zJlBld1USCYn+JR93t7Tw/0AkTpoFwOFe9Guu3o78
+Y5lr2wjp+zV0qlDVTXU4enxSVIigEJvPsLbo2DbE0i6BOoeutD0BC9O8zJzwO+OM
+g3zaBmfvAgMBAAECggEAD7l+veTHIb/rI5npHcNDTPi2uZFrwIBVgUhHuIayAtaS
+3wVFLZxueXBqc0IbMqvYe5KTTl3lJ0CdxJO34/3nWYaRxEmfK3t1dqYoPQuFjR/m
+ub4gkgDCwD4uEUfet8x1qmL04vbekVwRg4pSFRAtDMzCET2DRWPzxDPr/eqFpFrE
+e0wrJ3TzfDFIL1pbEF4yRQFcyl2nICECM316+mWUSslxLUU/oAWpYQnD6+YRFS2Z
+depRhfMd/bGC7bqRE0ax/qzWxd1ZcQ6HVwMN8TTe+1KEDFLFkNb8sp2ZgbdJQXyF
+9jRTv6ICT1GSksGi1r7PYrHS27XUbIkNq9SNR9dFYQKBgQDuxDyugqss1mF7FU78
+Cb1SqsXBCS5bGOX0PCsg0eB5IYb6PmxN7WD0GmnxG+76IRD2qjzy7NKmzspCQ1by
+RAynD0Qvz0mQqMIc8zvVH7XwvUFCiI9STNE9r5mY6ldcfeUeuhxlw34A4qIYZxfJ
+rHEpp8NP5ZlPc7QUOJZRcjPqsQKBgQDtXOGNTIZXr1VxQyH2mSFFjImbnXS77GSx
+S4P9kVs/Hon0c4CyryRfp7t3ID/qy1G17bknI4uPG6x3EJDG+5pBa3hE9o49067D
+rE1+4T7gZkdDxfL22vJe7sRk9Mled1BPdCd8NXqpFEtenzYRTgJI4sIh+c8ma5Df
+ZIXGB2LknwKBgFhttUuseVkRzOiY67fMo6GKPdNQYyq5/fCGmDJ/iHNUR3lGxTXX
+RKEjZzk07z0UIgQ46HnP2/SLgb0o03rGWSlGLirGyqgY2EuAihhUtj2C2jiZ+vqw
+GI6QCoLnx5MpzUGkDABkdrY9OWtwQw8eHose5ucgUbdrUrZqfsGLWk8BAoGALOVg
+lEVhM7yqQJ4eEnKsZGdMr+58Yf84nIBYGuIfjDTOizo9oY6XJrCnOMUU0ehbMDoi
+x1Bl2U+2s16iw8BbUPxu5zxrcy5S5Bf3IISiS/eMizkp159aMLKg2yeh3whaXGzv
++wJyjQCVsPQUWfmTXQ3nAl4p3G6EHHz7AJXtEqkCgYA8x/4chaaxita9ffFX++9r
+vEbENm2b8GUeOMXlKSynGLjdkr20jfGfYU6m60bKaQIfMcjc/h0iImmAvue9nMj1
+YaJP9/2UwN00nA+KTHDRuTUiWCMTuObxX3m9dPD1fdzga3730en30hJi0mqSoEYk
+HzaKGnNQMgKsNg2jkprTwA==
+-----END PRIVATE KEY-----"
+    public-key: "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3WJNEaB5yYDKkuS1Bjw4
+/MGQfIQPSMM7NUcpyQc73Q46RaGHuGAio7aFZifXWMODrh2+1APu55/s7XBFDqwY
+04FA4sOkHBTzMTMHYWHeRNK7LqCZ/fvAez054TMXBkd2q4Hpjs7BCzLrBokGnta0
+i8kpvadETEoyRgvHkQyRyLSHRrcWqtkHMozDWrnImujb0MefurwHjiAnZlb88bM0
+uSZSxPoyAu/Di8Ot8yZQZXdVEgmJ/iUfd7e08P9AJE6aBcDhXvRrrt6O/GOZa9sI
+6fs1dKpQ1U11OHp8UlSIoBCbz7C26Ng2xNIugTqHrrQ9AQvTvMyc8DvjjIN82gZn
+7wIDAQAB
+-----END PUBLIC KEY-----"
 
 app:
   default-admin:

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -16,7 +16,7 @@ spring:
     enabled: true
   output:
     ansi:
-      enabled: ALWAYS
+      enabled: DETECT
 
 adapters:
   r2dbc:

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -14,9 +14,15 @@ spring:
     password: ${SPRING_DB_PASSWORD}
     locations: "classpath:db/migration"
     enabled: true
-  output:
-    ansi:
-      enabled: DETECT
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${SECURITY_PUBLIC_KEY_URI}
+
+    output:
+      ansi:
+        enabled: DETECT
 
 adapters:
   r2dbc:
@@ -58,7 +64,8 @@ springdoc:
 
 security:
   jwt:
-    secret: ${JWT_SECRET}
+    private-key: "${JWT_PRIVATE_KEY}"
+    public-key: "${JWT_PUBLIC_KEY}"
     expiration: ${JWT_EXPIRATION:3600}
 
 app:

--- a/domain/model/src/main/java/co/com/pragma/model/constants/ErrorMessage.java
+++ b/domain/model/src/main/java/co/com/pragma/model/constants/ErrorMessage.java
@@ -54,6 +54,9 @@ public final class ErrorMessage {
     public static final String INVALID_CREDENTIALS_CODE = "IC001";
     public static final String INVALID_CREDENTIALS = "Invalid credentials.";
 
+    public static final String INVALID_KEY_CODE = "K001";
+    public static final String INVALID_KEY = "There was an error processing the cryptographic keys.";
+
     public static final String INVALID_ENDPOINT_CODE = "IE001";
     public static final String INVALID_ENDPOINT = "Invalid endpoint.";
 

--- a/domain/model/src/main/java/co/com/pragma/model/exceptions/KeyException.java
+++ b/domain/model/src/main/java/co/com/pragma/model/exceptions/KeyException.java
@@ -1,0 +1,12 @@
+package co.com.pragma.model.exceptions;
+
+import co.com.pragma.model.constants.ErrorMessage;
+
+import java.net.HttpURLConnection;
+
+public class KeyException extends CustomException {
+
+    public KeyException() {
+        super(ErrorMessage.INVALID_KEY, ErrorMessage.INVALID_KEY_CODE, HttpURLConnection.HTTP_INTERNAL_ERROR);
+    }
+}

--- a/domain/model/src/main/java/co/com/pragma/model/jwt/gateways/JwtProviderPort.java
+++ b/domain/model/src/main/java/co/com/pragma/model/jwt/gateways/JwtProviderPort.java
@@ -3,8 +3,11 @@ package co.com.pragma.model.jwt.gateways;
 import co.com.pragma.model.jwt.JwtData;
 import co.com.pragma.model.user.User;
 
+import java.security.PublicKey;
+
 public interface JwtProviderPort {
 
     String generateToken(User user);
     JwtData getClaims(String token);
+    PublicKey getPublicKey() throws Exception;
 }

--- a/infrastructure/driven-adapters/jwt-adapter/src/main/java/co/com/pragma/jwtadapter/JwtProviderAdapter.java
+++ b/infrastructure/driven-adapters/jwt-adapter/src/main/java/co/com/pragma/jwtadapter/JwtProviderAdapter.java
@@ -1,18 +1,23 @@
 package co.com.pragma.jwtadapter;
 
 import co.com.pragma.jwtadapter.config.JwtProperties;
+import co.com.pragma.model.exceptions.KeyException;
 import co.com.pragma.model.jwt.JwtData;
 import co.com.pragma.model.jwt.gateways.JwtProviderPort;
 import co.com.pragma.model.user.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
-import javax.crypto.SecretKey;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
@@ -28,23 +33,23 @@ public class JwtProviderAdapter implements JwtProviderPort {
     @Override
     public String generateToken(User user) {
         Map<String, Object> claims = new HashMap<>();
-        claims.put("role",user.getRole().getName());
-        claims.put("roleId",user.getRole().getRolId());
-        claims.put("name",user.getName() + " " + user.getLastName());
-        claims.put("idNumber",user.getIdNumber());
+        claims.put("role", user.getRole().getName());
+        claims.put("roleId", user.getRole().getRolId());
+        claims.put("name", user.getName() + " " + user.getLastName());
+        claims.put("idNumber", user.getIdNumber());
 
         return Jwts.builder()
                 .setClaims(claims)
                 .setSubject(user.getEmail())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration() * 1000))
-                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .signWith(getPrivateKey(), SignatureAlgorithm.RS256)
                 .compact();
     }
 
     @Override
     public JwtData getClaims(String token) {
-        Claims claims = Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token).getBody();
+        Claims claims = Jwts.parserBuilder().setSigningKey(getPublicKey()).build().parseClaimsJws(token).getBody();
         String subject = claims.getSubject();
         String role = claims.get("role", String.class);
         Integer roleId = claims.get("roleId", Integer.class);
@@ -53,8 +58,30 @@ public class JwtProviderAdapter implements JwtProviderPort {
         return new JwtData(subject, role, roleId, name, idNumber);
     }
 
-    private SecretKey getSigningKey() {
-        byte[] keyBytes = Base64.getDecoder().decode(jwtProperties.getSecret());
-        return Keys.hmacShaKeyFor(keyBytes);
+    @Override
+    @SneakyThrows(Exception.class)
+    public PublicKey getPublicKey() {
+        String publicKeyPEM = jwtProperties.getPublicKey()
+                .replace("-----BEGIN PUBLIC KEY-----", "")
+                .replaceAll(System.lineSeparator(), "")
+                .replace("-----END PUBLIC KEY-----", "")
+                .replaceAll("\\s", "");
+        byte[] keyBytes = Base64.getDecoder().decode(publicKeyPEM);
+        X509EncodedKeySpec spec = new X509EncodedKeySpec(keyBytes);
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        return kf.generatePublic(spec);
+    }
+
+    @SneakyThrows(Exception.class)
+    private PrivateKey getPrivateKey() {
+        String privateKeyPEM = jwtProperties.getPrivateKey()
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replaceAll(System.lineSeparator(), "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+        byte[] keyBytes = Base64.getDecoder().decode(privateKeyPEM);
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        return kf.generatePrivate(spec);
     }
 }

--- a/infrastructure/driven-adapters/jwt-adapter/src/main/java/co/com/pragma/jwtadapter/config/JwtProperties.java
+++ b/infrastructure/driven-adapters/jwt-adapter/src/main/java/co/com/pragma/jwtadapter/config/JwtProperties.java
@@ -7,6 +7,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "security.jwt")
 public class JwtProperties {
 
-    private String secret;
+    private String privateKey;
+    private String publicKey;
     private Long expiration = 3600L;
 }

--- a/infrastructure/entry-points/reactive-web/build.gradle
+++ b/infrastructure/entry-points/reactive-web/build.gradle
@@ -19,4 +19,8 @@ dependencies {
 
     //JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.37.3'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/RouterRest.java
@@ -35,6 +35,9 @@ public class RouterRest {
         ).andRoute(
                 GET(ApiConstants.ApiPaths.USERS_BY_FILTER_PATH),
                 handler::listenGETUsersByFilterUseCase
+        ).andRoute(
+                GET(ApiConstants.ApiPaths.JWKS_PATH),
+                handler::listenGETJWKSKey
         );
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/config/WebSecurityConfig.java
@@ -3,36 +3,30 @@ package co.com.pragma.api.config;
 import co.com.pragma.api.constants.ApiConstants;
 import co.com.pragma.api.constants.ApiConstants.ApiPathMatchers;
 import co.com.pragma.api.exception.handler.CustomAccessDeniedHandler;
-import co.com.pragma.model.exceptions.InvalidCredentialsException;
-import co.com.pragma.model.jwt.JwtData;
-import co.com.pragma.model.jwt.gateways.JwtProviderPort;
-import co.com.pragma.model.logs.gateways.LoggerPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.web.server.SecurityWebFilterChain;
-import org.springframework.security.web.server.context.ServerSecurityContextRepository;
-import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Configuration
 @EnableWebFluxSecurity
 @RequiredArgsConstructor
 public class WebSecurityConfig {
 
-    private final JwtProviderPort jwtProvider;
     private final CustomAccessDeniedHandler accessDeniedHandler;
-    private final LoggerPort logger;
 
     @Bean
     public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
@@ -41,13 +35,18 @@ public class WebSecurityConfig {
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
                 .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
-                .securityContextRepository(new JwtSecurityContextRepository())
+                .oauth2ResourceServer(spec ->
+                        spec.jwt(jwt ->
+                                jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())
+                        )
+                )
                 .authorizeExchange(spec -> spec
                         .pathMatchers(
                                 ApiPathMatchers.LOGIN_MATCHER,
                                 ApiPathMatchers.API_DOCS_MATCHER,
                                 ApiPathMatchers.SWAGGER_UI_MATCHER,
-                                ApiConstants.ApiPaths.SWAGGER_PATH
+                                ApiConstants.ApiPaths.SWAGGER_PATH,
+                                ApiConstants.ApiPaths.JWKS_PATH
                         ).permitAll()
                         .pathMatchers(
                                 ApiPathMatchers.HEALTH_CHECK_MATCHER
@@ -80,30 +79,28 @@ public class WebSecurityConfig {
                 .build();
     }
 
-    private class JwtSecurityContextRepository implements ServerSecurityContextRepository {
-        @Override
-        public Mono<Void> save(ServerWebExchange exchange, SecurityContext context) {
-            return Mono.empty();
-        }
+    private Converter<Jwt, Mono<AbstractAuthenticationToken>> jwtAuthenticationConverter() {
+        return jwt -> {
+            Collection<String> roles = extractRoles(jwt);
+            var authorities = roles.stream()
+                    .filter(r -> r != null && !r.isBlank())
+                    .map(org.springframework.security.core.authority.SimpleGrantedAuthority::new)
+                    .collect(Collectors.toSet());
 
-        @Override
-        public Mono<SecurityContext> load(ServerWebExchange exchange) {
-            String token = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+            return Mono.just(new JwtAuthenticationToken(jwt, authorities, jwt.getSubject()));
+        };
+    }
 
-            if (token != null && token.startsWith("Bearer ")) {
-                String authToken = token.substring(7);
-                try {
-                    JwtData jwtData = jwtProvider.getClaims(authToken);
-                    String email = jwtData.subject();
-                    List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(jwtData.role()));
-                    Authentication auth = new UsernamePasswordAuthenticationToken(email, authToken, authorities);
-                    logger.info("User {} logged in, with role {}", email, jwtData.role());
-                    return Mono.just(new SecurityContextImpl(auth));
-                } catch (Exception e) {
-                    return Mono.error(new InvalidCredentialsException());
-                }
-            }
-            return Mono.empty();
+    private Collection<String> extractRoles(Jwt jwt) {
+        Object single = jwt.getClaims().get("role");
+        Object multiple = jwt.getClaims().get("roles");
+
+        if (multiple instanceof Collection<?> col) {
+            return col.stream().map(Object::toString).collect(Collectors.toSet());
         }
+        if (single instanceof String s) {
+            return Set.of(s);
+        }
+        return List.of();
     }
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/constants/ApiConstants.java
@@ -24,6 +24,7 @@ public class ApiConstants {
         public static final String SEARCHES_PATH = BASE_PATH + "/busquedas";
         public static final String USERS_BY_FILTER_PATH = SEARCHES_PATH + "/filtro";
         public static final String LOGIN_PATH = BASE_PATH + "/login";
+        public static final String JWKS_PATH = "/.well-known/jwks.json";
         public static final String USER_BY_ID_NUMBER_PATH = USERS_PATH + "/{"+ApiParams.ID_NUMBER_PARAM+"}";
         public static final String USERS_BY_EMAIL_PATH = SEARCHES_PATH + "/emails";
         public static final String USER_EMAILS_BY_FILTER_PATH = SEARCHES_PATH + "/filtro";

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/exception/handler/CustomAccessDeniedHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/api/exception/handler/CustomAccessDeniedHandler.java
@@ -2,27 +2,44 @@ package co.com.pragma.api.exception.handler;
 
 import co.com.pragma.api.dto.ErrorDTO;
 import co.com.pragma.model.constants.ErrorMessage;
+import co.com.pragma.model.logs.gateways.LoggerPort;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.server.authorization.ServerAccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
+import java.net.InetSocketAddress;
 import java.time.Instant;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements ServerAccessDeniedHandler {
 
     private final ObjectMapper objectMapper;
+    private final LoggerPort logger;
 
     @Override
     public Mono<Void> handle(ServerWebExchange exchange, AccessDeniedException denied) {
+
+        String path = exchange.getRequest().getPath().value();
+        InetSocketAddress remoteAddress = exchange.getRequest().getRemoteAddress();
+        String clientIp = remoteAddress != null ? remoteAddress.getAddress().getHostAddress() : "unknown";
+
+        logger.warn("Access denied path=[{}] ip=[{}] reason=[{}]",
+                path, clientIp, denied.getMessage());
+
+        logAuthDetails(exchange);
+
         exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
         exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
 
@@ -35,5 +52,48 @@ public class CustomAccessDeniedHandler implements ServerAccessDeniedHandler {
 
         DataBufferFactory bufferFactory = exchange.getResponse().bufferFactory();
         return exchange.getResponse().writeWith(Mono.fromCallable(() -> bufferFactory.wrap(objectMapper.writeValueAsBytes(errorDTO))));
+    }
+
+
+    private void logAuthDetails(ServerWebExchange exchange) {
+        String authHeader = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            // Huella no reversible del token (NO loguear el JWT completo)
+            String token = authHeader.substring(7);
+            String fingerprint = Integer.toHexString(token.hashCode());
+            logger.debug("Denied token fingerprint=[{}]", fingerprint);
+        } else {
+            logger.debug("No Bearer token present");
+        }
+
+        exchange.getPrincipal()
+                .doOnNext(principal -> {
+                    if (principal instanceof Authentication authentication) {
+                        String authorities = authentication.getAuthorities()
+                                .stream()
+                                .map(GrantedAuthority::getAuthority)
+                                .collect(Collectors.joining(","));
+                        logger.debug("Denied authentication name=[{}] authenticated=[{}] authorities=[{}] details=[{}]",
+                                authentication.getName(),
+                                authentication.isAuthenticated(),
+                                authorities,
+                                authentication.getDetails());
+                    } else {
+                        logger.debug("Denied principal type=[{}] name=[{}]",
+                                principal.getClass().getSimpleName(),
+                                principal.getName());
+                    }
+                })
+                .switchIfEmpty(Mono.fromRunnable(() ->
+                        logger.debug("Denied request without principal (anonymous)")))
+                .subscribe(); // Side-effect logging
+    }
+
+    private byte[] writeBytes(ErrorDTO dto) throws RuntimeException {
+        try {
+            return objectMapper.writeValueAsBytes(dto);
+        } catch (Exception e) {
+            throw new RuntimeException("Error serializando ErrorDTO", e);
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces major changes to migrate JWT handling from symmetric (HMAC) to asymmetric (RSA) cryptography, improves OAuth2 resource server integration, and adds a JWKS endpoint for public key distribution. It also includes configuration and dependency updates to support these enhancements, and introduces improved error handling for cryptographic key issues.

**JWT and Security Enhancements:**

* Migrated JWT signing from HMAC (using a shared secret) to RSA (using private/public key pair), updating `JwtProviderAdapter` to use `RS256` for signing and verification, and modifying the configuration properties and YAML files to store and load RSA keys instead of a secret. (`[[1]](diffhunk://#diff-f371dbc2c6317e015ce379bf1d50c847a119d4c796a7a9149ce6bc96055c99f9L41-R52)`, `[[2]](diffhunk://#diff-8f699f2962298647259ed5cf9dceeb0a73bd1b3d3b623d99b90317325f7144e7L10-R11)`, `[[3]](diffhunk://#diff-5b822eec1940d21575d266bf27703aa0e5531d71306021102bba4b51a5224ea3R20-R65)`, `[[4]](diffhunk://#diff-13558ad2b7d64d2abb71070b44165e7110a99238a701565d40192be7ac95c948L61-R68)`)
* Updated the Spring Security configuration to use the OAuth2 resource server with JWT validation, leveraging the public key and supporting the `jwk-set-uri` property for dynamic key retrieval. (`[[1]](diffhunk://#diff-212223003c0b8b49cd05b516c0774d044949dbc747bd182d586d832d3feddb32L6-L35)`, `[[2]](diffhunk://#diff-212223003c0b8b49cd05b516c0774d044949dbc747bd182d586d832d3feddb32L44-R49)`, `[[3]](diffhunk://#diff-5b822eec1940d21575d266bf27703aa0e5531d71306021102bba4b51a5224ea3R6-R10)`, `[[4]](diffhunk://#diff-13558ad2b7d64d2abb71070b44165e7110a99238a701565d40192be7ac95c948R17-R25)`)
* Added detailed debug logging for JWT processing and security-related components to aid in troubleshooting. (`[applications/app-service/src/main/resources/application-local.yamlR20-R65](diffhunk://#diff-5b822eec1940d21575d266bf27703aa0e5531d71306021102bba4b51a5224ea3R20-R65)`)

**Public Key Distribution (JWKS):**

* Introduced a new endpoint (`/.well-known/jwks.json`) that exposes the application's RSA public key in JWKS format, allowing external services to verify JWT signatures. This includes a new handler method and router configuration. (`[[1]](diffhunk://#diff-30a1c71b2c4e945bb0fc4ff31717f20a1a254d569f9af70d81da6de8c223c3feR149-R165)`, `[[2]](diffhunk://#diff-d500273ba1e41b0042c9750a80ea4c49651271e61bda8437be3a61d4469b61f3R38-R40)`)

**Error Handling Improvements:**

* Added a new `KeyException` class and related error messages to provide clear feedback when there are issues processing cryptographic keys. (`[[1]](diffhunk://#diff-4ae430955bda29f4a6d7277270c7ec12e88de0e2f9406cf827ac0f25ca22a9e0R57-R59)`, `[[2]](diffhunk://#diff-b4f8ffe2b42fe68753c2949afa9d361886de350941566d3c81852aa31a3f760aR1-R12)`)

**Infrastructure and Dependency Updates:**

* Added dependencies for `nimbus-jose-jwt` and `spring-boot-starter-oauth2-resource-server` to support JWT and JWKS operations. (`[infrastructure/entry-points/reactive-web/build.gradleR22-R25](diffhunk://#diff-7d00462b4800b1e1880d6f151a1fd3da6645966982d4632018ffb8c72098bdbcR22-R25)`)

**CI/CD Adjustments:**

* Modified the GitHub Actions workflow for Docker image deployment to ECR, changing the trigger from tags to the `main` branch and updating Docker tag logic. (`[[1]](diffhunk://#diff-60eec17adfb8d24f5ce97d54e88ff4f86d271c19ac3d165b07a0091ed363d01aL6-R7)`, `[[2]](diffhunk://#diff-60eec17adfb8d24f5ce97d54e88ff4f86d271c19ac3d165b07a0091ed363d01aL45-R45)`)